### PR TITLE
delete and edit habits

### DIFF
--- a/Completeness/Services/HabitCRUD/HabitRepository.swift
+++ b/Completeness/Services/HabitCRUD/HabitRepository.swift
@@ -52,7 +52,10 @@ class HabitRepository: HabitRepositoryProtocol {
     func editHabit() {
         //edit habits
     }
-    func deleteHabit() {
-        //delete habits
+    func deleteHabit(id: UUID) {
+        if let habitToDelete = getHabitById(id: id) {
+            context.delete(habitToDelete)
+            try? context.save()
+        }
     }
 }

--- a/Completeness/Services/HabitCRUD/HabitRepository.swift
+++ b/Completeness/Services/HabitCRUD/HabitRepository.swift
@@ -15,6 +15,7 @@ class HabitRepository: HabitRepositoryProtocol {
     init(context: ModelContext) {
         self.context = context
     }
+    
     func getAllHabits() throws -> [Habit] {
         let descriptor = FetchDescriptor<Habit>()
         do {
@@ -49,8 +50,8 @@ class HabitRepository: HabitRepositoryProtocol {
             fatalError()
         }
     }
-    func editHabit() {
-        //edit habits
+    func saveChanges() {
+        try? context.save()
     }
     func deleteHabit(id: UUID) {
         if let habitToDelete = getHabitById(id: id) {

--- a/Completeness/Services/HabitCRUD/HabitRepositoryProtocol.swift
+++ b/Completeness/Services/HabitCRUD/HabitRepositoryProtocol.swift
@@ -12,5 +12,5 @@ protocol HabitRepositoryProtocol {
     func getHabitById(id: UUID) -> Habit?
     func createHabit(habit: Habit)
     func editHabit()
-    func deleteHabit()
+    func deleteHabit(id: UUID)
 }

--- a/Completeness/Services/HabitCRUD/HabitRepositoryProtocol.swift
+++ b/Completeness/Services/HabitCRUD/HabitRepositoryProtocol.swift
@@ -11,6 +11,6 @@ protocol HabitRepositoryProtocol {
     func getAllHabits() throws -> [Habit]
     func getHabitById(id: UUID) -> Habit?
     func createHabit(habit: Habit)
-    func editHabit()
+    func saveChanges()
     func deleteHabit(id: UUID)
 }

--- a/Completeness/ViewModel/Habits/HabitsViewModel.swift
+++ b/Completeness/ViewModel/Habits/HabitsViewModel.swift
@@ -67,6 +67,10 @@ final class HabitsViewModel: HabitsProtocol {
         self.completenessType == .byMultipleToggle
     }
     
+    func deleteHabit(by id: UUID) {
+        habitService.deleteHabit(id: id)
+    }
+    
     @MainActor
     func loadData() async {
         do {

--- a/Completeness/ViewModel/Habits/HabitsViewModel.swift
+++ b/Completeness/ViewModel/Habits/HabitsViewModel.swift
@@ -26,6 +26,7 @@ final class HabitsViewModel: HabitsProtocol {
     var textField = ""
     var completenessType: CompletionHabit = .byToggle
     var howManyTimesToCompleteHabit = 1
+    var habitToEdit: Habit = .init(howManyTimesToToggle: 1)
     
     init(habitCompletionService: HabitCompletionProtocol, habitService: HabitRepositoryProtocol) {
         self.habitCompletionService = habitCompletionService
@@ -48,7 +49,6 @@ final class HabitsViewModel: HabitsProtocol {
             howManyTimesToToggle: howManyTimesToCompleteHabit
         )
         
-        //        howManyTimesToCompleteHabit = 1 ?? pq isso
         habitService.createHabit(habit: newHabit)
         Task{
             await loadData()
@@ -69,6 +69,10 @@ final class HabitsViewModel: HabitsProtocol {
     
     func deleteHabit(by id: UUID) {
         habitService.deleteHabit(id: id)
+    }
+    
+    func editHabit() {
+        habitService.saveChanges()
     }
     
     @MainActor

--- a/Completeness/Views/Tests/HabitsPOCView.swift
+++ b/Completeness/Views/Tests/HabitsPOCView.swift
@@ -9,6 +9,7 @@ import SwiftData
 
 struct HabitsPOCView: View {
     @Bindable var viewModel: HabitsViewModel
+    @State private var editHabitsSheet = false
     
     var body: some View {
         VStack(alignment: .center, spacing: 16){
@@ -38,9 +39,6 @@ struct HabitsPOCView: View {
 
             Button {
                 viewModel.createNewHabit()
-                viewModel.habits.forEach({habit
-                    in print(habit.habitName)
-                })
             } label: {
                 Text("Save New Habit")
             }
@@ -81,6 +79,10 @@ struct HabitsPOCView: View {
                         await viewModel.loadData()
                     }
                 })
+                .onTapGesture {
+                    viewModel.habitToEdit = habit
+                    editHabitsSheet = true
+                }
             }
         }
         .frame(alignment: .leading)
@@ -88,5 +90,8 @@ struct HabitsPOCView: View {
         .task {
             await viewModel.loadData()
         }
+        .sheet(isPresented: $editHabitsSheet, content: {
+            SheetToEditHabitsTest(habit: viewModel.habitToEdit, editHabit: {viewModel.editHabit()})
+        })
     }
 }

--- a/Completeness/Views/Tests/HabitsPOCView.swift
+++ b/Completeness/Views/Tests/HabitsPOCView.swift
@@ -75,6 +75,12 @@ struct HabitsPOCView: View {
                     }
                 }
                 .frame(maxWidth: .infinity)
+                .onLongPressGesture(perform: {
+                    viewModel.deleteHabit(by: habit.id)
+                    Task {
+                        await viewModel.loadData()
+                    }
+                })
             }
         }
         .frame(alignment: .leading)

--- a/Completeness/Views/Tests/SheetToEditHabitsTest.swift
+++ b/Completeness/Views/Tests/SheetToEditHabitsTest.swift
@@ -1,0 +1,51 @@
+//
+//  SwiftUIView.swift
+//  Completeness
+//
+//  Created by Gustavo Ferreira bassani on 17/09/25.
+//
+
+import SwiftUI
+
+struct SheetToEditHabitsTest: View {
+    @Environment(\.dismiss) private var dismiss
+    @Bindable var habit: Habit
+    var editHabit: () -> Void
+    
+    var body: some View {
+        VStack(alignment: .center) {
+            Text("editar nome do hábito")
+            TextField("so de teste", text: $habit.habitName)
+            
+            Picker("Completion Type", selection: $habit.habitCompleteness) {
+                Text("Toggle simples").tag(CompletionHabit.byToggle)
+                Text("Toggle multiplo").tag(CompletionHabit.byMultipleToggle)
+                Text("By Timer").tag(CompletionHabit.byTimer)
+            }
+            
+            if habit.habitCompleteness == .byMultipleToggle {
+                HStack {
+                    Text("choose how many times you want to do it for a day")
+                    
+                    Picker("How many times", selection: $habit.howManyTimesToToggle) {
+                        ForEach(1..<10, id: \.self) { count in
+                            Text("\(count)").tag(count)
+                        }
+                    }
+                }
+            }
+
+            Button {
+                editHabit()
+                dismiss()
+            } label: {
+                Text("Save Changes")
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+//    SheetToEditHabitsTest()
+}


### PR DESCRIPTION
## Description

The habits can be deleted by long press and can be edited with single tap.
the main reason for this PR is to create service functions and viewmodel functions to do this. 
the CRUD for habits is done now.

## Relates to:

### US02# - Metas e hábitos (pré-definidos)

- TK16# - implementar persistência dos hábitos
